### PR TITLE
fix mixup between binary and UInt8 lists

### DIFF
--- a/src/protocols.jl
+++ b/src/protocols.jl
@@ -148,7 +148,7 @@ read(p::TBinaryProtocol, ::Type{TDOUBLE})       = reinterpret(TDOUBLE, _read_fix
 read!(p::TBinaryProtocol, a::Array{UInt8,1})    = read!(p.t, a)
 read(p::TBinaryProtocol, ::Type{ASCIIString})   = convert(ASCIIString, read(p, Vector{UInt8}))
 read(p::TBinaryProtocol, ::Type{UTF8String})    = convert(UTF8String, read(p, Vector{UInt8}))
-read(p::TBinaryProtocol, ::Type{Vector{UInt8}}) = read!(p, Array(UInt8, readI32(p)))
+read(p::TBinaryProtocol, ::Type{Vector{UInt8}}) = read!(p, Array(UInt8, _read_fixed(p.t, UInt32(0), 4, true)))
 
 # ==========================================
 # Binary Protocol End

--- a/src/sasl.jl
+++ b/src/sasl.jl
@@ -118,5 +118,8 @@ end
 function sasl_callback_default(part::Symbol)
     (part == :authcid) && (return get(ENV, "USER", ""))
     (part == :passwd) && (return "password")
+    (part == :show) && (return get(ENV, "USER", ""))
+    (part == :mechanism) && (return "SASL-Plain")
+
     return "" # for authzid
 end

--- a/src/transports.jl
+++ b/src/transports.jl
@@ -69,6 +69,7 @@ readframesz(t::TFramedTransport) = _read_fixed(t.tp, UInt32(0), 4, true)
 function readframe(t::TFramedTransport)
     @logmsg("TFramedTransport reading frame")
     sz = readframesz(t)
+    @logmsg("TFramedTransport reading frame of $sz bytes")
     write(t.rbuff, read!(t.tp, Array(UInt8, sz)))
     @logmsg("TFramedTransport read frame of $sz bytes")
     nothing
@@ -82,6 +83,7 @@ function read!(t::TFramedTransport, buff::Array{UInt8,1})
         navlb = nb_available(t.rbuff)
         nremain = ntotal - nread
         if navlb < nremain
+            @logmsg("navlb: $navlb, nremain: $nremain, reading new frame")
             readframe(t)
             navlb = nb_available(t.rbuff)
         end


### PR DESCRIPTION
Reading of binary types and thrift lists were mixed up as both are `UInt8[]`. Looking at the thrift metadata now to disambiguate them.

Adding an optional callback param for auth callbacks that can be used in the `show` method.