### PR TITLE
memory transport, update reserved symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Transport      | Implemented as               | &nbsp;
 Socket         | TSocket and TServerSocket    |
 Framed         | TFramedTransport             |
 SASL           | TSASLClientTransport         | Only client side implementation as of now
+Memory         | TMemoryTransport             | Can't be used with servers as of now
 
 Server                      | Implemented as               | &nbsp;
 ---                         | ---                          | ---

--- a/compiler/t_jl_generator.cc
+++ b/compiler/t_jl_generator.cc
@@ -26,7 +26,8 @@ static const std::vector<string> julia_keywords = {
 	"try", "catch", "return", "local", "abstract", "function", "macro",
 	"ccall", "finally", "typealias", "break", "continue", "type",
 	"global", "module", "using", "import", "export", "const", "let",
-	"bitstype", "do", "baremodule", "importall", "immutable"
+	"bitstype", "do", "baremodule", "importall", "immutable",
+	"Type"
 };
 
 
@@ -265,7 +266,7 @@ string t_jl_generator::chk_keyword(const string &value) {
  */
 void t_jl_generator::generate_enum(t_enum* tenum) {
 	vector<t_enum_value*> constants = tenum->get_constants();
-	string enum_name = tenum->get_name();
+	string enum_name = chk_keyword(tenum->get_name());
 
 	f_types_ << indent() << "type " << "_enum_" << enum_name << endl;
 	indent_up();

--- a/src/Thrift.jl
+++ b/src/Thrift.jl
@@ -19,7 +19,7 @@ export isinitialized, set_field, set_field!, get_field, clear, has_field, fillun
 
 
 # from transports.jl
-export TFramedTransport, TSASLClientTransport, TSocket, TServerSocket, TSocketBase
+export TFramedTransport, TSASLClientTransport, TSocket, TServerSocket, TSocketBase, TMemoryTransport
 export TransportExceptionTypes, TTransportException
 
 # from sasl.jl

--- a/src/transports.jl
+++ b/src/transports.jl
@@ -162,3 +162,21 @@ write(tsock::TSocketBase, buff::Array{UInt8,1}) = write(tsock.io, buff)
 write(tsock::TSocketBase, b::UInt8) = write(tsock, b)
 flush(tsock::TSocketBase)   = flush(tsock.io)
 isopen(tsock::TSocketBase)  = (isdefined(tsock, :io) && isreadable(tsock.io) && iswritable(tsock.io))
+
+# Thrift Memory Transport
+type TMemoryTransport <: TTransport
+    buff::IOBuffer
+
+    TMemoryTransport() = new(PipeBuffer())
+    TMemoryTransport(buff::Array{UInt8}) = new(PipeBuffer(buff))
+end
+
+rawio(t::TMemoryTransport)  = t.buff
+open(t::TMemoryTransport)   = nothing
+close(t::TMemoryTransport)  = nothing
+isopen(t::TMemoryTransport) = true
+flush(t::TMemoryTransport)  = nothing
+read!(t::TMemoryTransport, buff::Array{UInt8,1}) = read!(t.buff, buff)
+read(t::TMemoryTransport, UInt8) = read(t.buff, UInt8)
+write(t::TMemoryTransport, buff::Array{UInt8,1}) = write(t.buff, buff)
+write(t::TMemoryTransport, b::UInt8) = write(t.buff, b)

--- a/test/memtransport_tests.jl
+++ b/test/memtransport_tests.jl
@@ -1,0 +1,16 @@
+using Thrift
+using Base.Test
+
+function testmemtransport()
+    println("\nTesting memory transport...")
+    t = TMemoryTransport()
+    p = TCompactProtocol(t)
+
+    s1 = "Hello World"
+    write(p, s1)
+    s2 = read(p, ASCIIString)
+    @test s2 == s1
+    println("Memory Transport tests passed.")
+end
+
+testmemtransport()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,5 @@ include("gen.jl")
 ENV["TEST_SRVR_ASYNC"] = "true"
 include("srvr.jl")
 include("clnt.jl")
+
+include("memtransport_tests.jl")


### PR DESCRIPTION
- include `Type` in reserved symbols
- handle reserved symbols while generating enums
- add `TMemoryTransport`, implemented using `PipeBuffer` (not available to be used with thrift server yet) 