### PR TITLE
added TFileTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Socket         | TSocket and TServerSocket    |
 Framed         | TFramedTransport             |
 SASL           | TSASLClientTransport         | Only client side implementation as of now
 Memory         | TMemoryTransport             | Can't be used with servers as of now
+File           | TFileTransport               | Can't be used with servers as of now
 
 Server                      | Implemented as               | &nbsp;
 ---                         | ---                          | ---

--- a/src/Thrift.jl
+++ b/src/Thrift.jl
@@ -19,7 +19,7 @@ export isinitialized, set_field, set_field!, get_field, clear, has_field, fillun
 
 
 # from transports.jl
-export TFramedTransport, TSASLClientTransport, TSocket, TServerSocket, TSocketBase, TMemoryTransport
+export TFramedTransport, TSASLClientTransport, TSocket, TServerSocket, TSocketBase, TMemoryTransport, TFileTransport
 export TransportExceptionTypes, TTransportException
 
 # from sasl.jl

--- a/src/transports.jl
+++ b/src/transports.jl
@@ -180,3 +180,18 @@ read!(t::TMemoryTransport, buff::Array{UInt8,1}) = read!(t.buff, buff)
 read(t::TMemoryTransport, UInt8) = read(t.buff, UInt8)
 write(t::TMemoryTransport, buff::Array{UInt8,1}) = write(t.buff, buff)
 write(t::TMemoryTransport, b::UInt8) = write(t.buff, b)
+
+# Thrift File IO Transport
+type TFileTransport <: TTransport
+    handle::IO
+end
+
+rawio(t::TFileTransport)  = t.handle
+open(t::TFileTransport)   = nothing
+close(t::TFileTransport)  = nothing
+isopen(t::TFileTransport) = true
+flush(t::TFileTransport)  = flush(t.handle)
+read!(t::TFileTransport, buff::Array{UInt8,1}) = read!(t.handle, buff)
+read(t::TFileTransport, UInt8) = read(t.handle, UInt8)
+write(t::TFileTransport, buff::Array{UInt8,1}) = write(t.handle, buff)
+write(t::TFileTransport, b::UInt8) = write(t.handle, b)

--- a/test/filetransport_tests.jl
+++ b/test/filetransport_tests.jl
@@ -1,0 +1,33 @@
+module FileTransportTests
+
+using Thrift
+using Base.Test
+
+function testfiletransport()
+    println("\nTesting file transport...")
+
+    fname = tempname()
+    s1 = "Hello World"
+    open(fname, "w") do f
+        t = TFileTransport(f)
+        p = TCompactProtocol(t)
+        for i in 1:5
+            write(p, s1)
+        end
+    end
+
+    open(fname, "r") do f
+        t = TFileTransport(f)
+        p = TCompactProtocol(t)
+        for i in 1:5
+            s2 = read(p, ASCIIString)
+            @test s2 == s1
+        end
+        println("passed.")
+    end
+    rm(fname)
+end
+
+testfiletransport()
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ include("srvr.jl")
 include("clnt.jl")
 
 include("memtransport_tests.jl")
+include("filetransport_tests.jl")
 include("utils_tests.jl")


### PR DESCRIPTION
Can be used to read/write thrift messages from/to an open file handle.
Servers can't still use this transport.