### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir and run tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ os:
     - osx
     - linux
 julia:
-    - nightly
     - 0.4
+    - 0.5
+    - nightly
 notifications:
     email: false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: julia
 os:
     - osx
     - linux
+sudo: required
+dist: trusty
 julia:
     - 0.4
     - 0.5
@@ -10,4 +12,4 @@ notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("Thrift");';
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("Thrift"); Pkg.test("Thrift")';

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: julia
 os:
-    - osx
     - linux
 sudo: required
 dist: trusty
@@ -8,8 +7,12 @@ julia:
     - 0.4
     - 0.5
     - nightly
+before_install:
+    - sudo apt-get update -qq -y
+    - sudo apt-get install -y libssl-dev flex bison libboost-all-dev
+    - sudo ./test/setup_thrift_compiler.sh
 notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("Thrift"); Pkg.test("Thrift")';
+    - PATH=/thrift/thrift/install/bin:$PATH julia -e 'Pkg.clone(pwd()); Pkg.build("Thrift"); Pkg.test("Thrift")'

--- a/test/gen.jl
+++ b/test/gen.jl
@@ -1,4 +1,4 @@
-testdir = joinpath(Pkg.dir("Thrift"), "test")
+testdir = dirname(@__FILE__)
 
 run(`thrift -gen jl srvcctrl.thrift`)
 run(`thrift -gen jl proto_tests.thrift`)

--- a/test/setup_thrift_compiler.sh
+++ b/test/setup_thrift_compiler.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Script to compile and install a thrift compiler with Julia extensions.
+# Used for CI tests.
+
+# apt packages required:
+# apt-get install libssl-dev flex bison libboost-all-dev
+
+if [ -z "$THRIFT_DIR" ]
+then
+    THRIFT_DIR=/thrift
+fi
+
+mkdir $THRIFT_DIR && \
+cd $THRIFT_DIR && \
+git clone https://github.com/tanmaykm/thrift.git && \
+cd $THRIFT_DIR/thrift && \
+git checkout julia && \
+mkdir $THRIFT_DIR/thrift/install && \
+cd $THRIFT_DIR/thrift && \
+./bootstrap.sh && \
+./configure --prefix=$THRIFT_DIR/thrift/install && \
+make install


### PR DESCRIPTION
- Use `dirname(@__FILE__)` instead of `Pkg.dir` (from #17)
- Install Thrift compiler for CI (from #17)
- Run the tests on Travis