### PR TITLE
Using deps/build.jl to build thrift

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,36 @@
+using BinDeps
+@BinDeps.setup
+bison = library_dependency("bison", aliases = ["bison"])
+# Wrap in @osx_only to avoid non-OSX users from erroring out
+@static if is_apple()
+    using Homebrew
+    provides( Homebrew.HB, "bison", bison, os = :Darwin )
+end
+
+#Dict(:bison => :jl_bison)
+try
+    @BinDeps.install
+end
+
+run(`pwd`)
+THRIFT_VERSION="0.9.3"
+THRIFT_PATH = "http://mirror.cc.columbia.edu/pub/software/apache/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz"
+thrifttar = "thrift.tar.gz"
+jlgeneratorcpp = "../compiler/t_jl_generator.cc"
+thriftgenerators = "thrift-$THRIFT_VERSION/compiler/cpp/src/generate/t_jl_generator.cc"
+info("downloading thrift sources")
+# download(THRIFT_PATH, thrifttar)
+info("extracting thrift sources")
+run(`tar xzf ./thrift.tar.gz -C ./`)
+run(`ls thrift-$THRIFT_VERSION`)
+info("Moving julia plugin into thrift sources")
+cp(jlgeneratorcpp, thriftgenerators, remove_destination=true)
+
+info("Buidling thrift compiler")
+build = Cmd(`./configure`,
+            dir="./thrift-$THRIFT_VERSION") &
+        Cmd(`make -j4`,
+            dir="./thrift-$THRIFT_VERSION")
+run(build)
+cp("./thrift-$THRIFT_VERSION/compiler/cpp/thrift", "./thrift", remove_destination=true)
+chmod("./thrift", 0o744)

--- a/test/gen.jl
+++ b/test/gen.jl
@@ -1,4 +1,5 @@
 testdir = dirname(@__FILE__)
+ENV["PATH"] = join([joinpath(dirname(@__FILE__), "deps"), ENV["PATH"]], ":")
 
 run(`thrift -gen jl srvcctrl.thrift`)
 run(`thrift -gen jl proto_tests.thrift`)


### PR DESCRIPTION
Here is a first attempt at using deps/build.jl to build thrift.
It just uses raw system commands rather than the BinDeps tool chain. We should be able to replace it with the Sources and Autotools provides from BinDeps which will make it more portable.