### PR TITLE
Don't run build.jl on Windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -86,7 +86,9 @@ function build_thrift()
     end
 end
 
-ensure_dirs()
-get_thrift()
-patch_thrift()
-build_thrift()
+if !is_windows()
+    ensure_dirs()
+    get_thrift()
+    patch_thrift()
+    build_thrift()
+end


### PR DESCRIPTION
This is crude, but at least it enables running things like Parquet.jl on Windows without errors during package installation. Would obviously be nicer if someone managed to get the compiler working on Windows as well, but I think this is better than nothing :)