### PR TITLE
migrate to thrift 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - julia: nightly
+    - os: osx
 addons:
   apt:
     packages:

--- a/compiler/t_jl_generator.cc
+++ b/compiler/t_jl_generator.cc
@@ -8,9 +8,9 @@
 #include <sys/types.h>
 #include <sstream>
 #include <algorithm>
-#include "t_generator.h"
-#include "platform.h"
-#include "version.h"
+#include "thrift/generate/t_oop_generator.h"
+#include "thrift/platform.h"
+#include "thrift/version.h"
 
 using std::map;
 using std::ofstream;
@@ -38,7 +38,7 @@ static const std::vector<string> julia_keywords = {
 class t_jl_generator: public t_generator {
 public:
 	t_jl_generator(t_program* program,
-			const std::map<std::string, std::string>& parsed_options,
+			__attribute__((unused)) const std::map<std::string, std::string>& parsed_options,
 			const std::string& option_string) :
 			t_generator(program) {
 		(void) option_string;
@@ -163,7 +163,7 @@ string t_jl_generator::julia_type(t_type *type) {
 			}
 		case t_base_type::TYPE_BOOL:
 			return "Bool";
-		case t_base_type::TYPE_BYTE:
+		case t_base_type::TYPE_I8:
 			return "UInt8";
 		case t_base_type::TYPE_I16:
 			return "Int16";
@@ -330,7 +330,7 @@ string t_jl_generator::render_const_value(t_type* type, t_const_value* value, bo
 		case t_base_type::TYPE_BOOL:
 			out << (value->get_integer() > 0 ? "true" : "false");
 			break;
-		case t_base_type::TYPE_BYTE:
+		case t_base_type::TYPE_I8:
 			if(with_conversion) {
 				out << "UInt8(" << value->get_integer() << ")";
 			}

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,3 +1,4 @@
 bin
 lib
 src
+include

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -34,20 +34,19 @@ const PREFIXES = Dict(
 for (n,v) in PREFIXES
     ENV[n] = v
 end
-const BUILD_ENV = isless(Base.VERSION, v"0.5.0-") ? ["$n=$v" for (n,v) in ENV] : ENV
 
-const THRIFT_VERSION="0.9.3"
+const THRIFT_VERSION="0.11.0"
 const THRIFT_GIT_SRC = "https://github.com/apache/thrift.git"
 const THRIFT_SRC = joinpath(DEPS_SRC, "thrift-$THRIFT_VERSION")
 
 const THRIFT_BUILD = [
-        Cmd(`./bootstrap.sh`, dir="$THRIFT_SRC", env=BUILD_ENV),
-        Cmd(`./configure --prefix=$DEPS_BIN --without-erlang --without-ruby --without-qt4 --without-qt5 --without-c_glib --without-csharp --without-java --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-haskell --without-go --without-haxe --without-d`, dir="$THRIFT_SRC", env=BUILD_ENV),
-        Cmd(`make install -j4`, dir="$THRIFT_SRC", env=BUILD_ENV)
+        Cmd(`./bootstrap.sh`, dir="$THRIFT_SRC", env=ENV),
+        Cmd(`./configure --prefix=$DEPS_BIN --without-erlang --without-ruby --without-qt4 --without-qt5 --without-c_glib --without-csharp --without-java --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-haskell --without-go --without-haxe --without-d`, dir="$THRIFT_SRC", env=ENV),
+        Cmd(`make install -j4`, dir="$THRIFT_SRC", env=ENV)
     ]
 const THRIFT_MKFILE = joinpath(THRIFT_SRC, "compiler", "cpp", "Makefile.am")
 const JL_PLUGIN_SRC = joinpath(PKG_DIR, "compiler", "t_jl_generator.cc")
-const JL_PLUGIN_DEST = joinpath(THRIFT_SRC, "compiler", "cpp", "src", "generate", "t_jl_generator.cc")
+const JL_PLUGIN_DEST = joinpath(THRIFT_SRC, "compiler", "cpp", "src", "thrift", "generate", "t_jl_generator.cc")
 
 function ensure_dirs()
     isdir(DEPS_SRC) || mkdir(DEPS_SRC)
@@ -61,7 +60,7 @@ function patch_thrift()
     makefile = readstring(THRIFT_MKFILE)
     if searchindex(makefile, "t_jl_generator") == 0
         info("Patching thrift makefile")
-        makefile = replace(makefile, "src/generate/t_lua_generator.cc", "src/generate/t_lua_generator.cc src/generate/t_jl_generator.cc")
+        makefile = replace(makefile, "src/thrift/generate/t_rs_generator.cc", "src/thrift/generate/t_rs_generator.cc src/thrift/generate/t_jl_generator.cc")
         open(THRIFT_MKFILE, "w") do f
             write(f, makefile)
         end

--- a/src/base.jl
+++ b/src/base.jl
@@ -3,7 +3,7 @@
 immutable TSTOP end
 const TVOID     = Void
 const TBOOL     = Bool
-const TBYTE     = UInt8
+const TBYTE     = UInt8     # TBYTE is actually I8 (signed)
 const TDOUBLE   = Float64
 const TI16      = Int16
 const TI32      = Int32

--- a/test/proto_tests.thrift
+++ b/test/proto_tests.thrift
@@ -37,7 +37,7 @@ enum TestEnum {
 
 struct AllTypesDefault {
     1: optional bool bool_val = true,
-    2: optional byte byte_val = 1,
+    2: optional i8 byte_val = 1,
     3: optional i16 i16_val = 10,
     4: optional i32 i32_val = 20,
     5: optional i64 i64_val = 30,
@@ -45,12 +45,12 @@ struct AllTypesDefault {
     7: optional string string_val = "hello world",
     8: optional map<i32,i16> map_val = {1:10, 2:20},
     9: optional list<i16> list_val = [1,2,3],
-    10: optional set<byte> set_val = [3,4,5]
+    10: optional set<i8> set_val = [3,4,5]
 }
 
 struct AllTypes {
     1: bool bool_val,
-    2: byte byte_val,
+    2: i8 byte_val,
     3: i16 i16_val,
     4: i32 i32_val,
     5: i64 i64_val,
@@ -58,7 +58,7 @@ struct AllTypes {
     7: string string_val,
     8: map<i32,i16> map_val,
     9: list<i16> list_val,
-    10: set<byte> set_val
+    10: set<i8> set_val
 }
 
 service ProtoTests extends srvcctrl.ServiceControl {


### PR DESCRIPTION
- migrated to the recently released Thrift 0.11.0 version
- updated travis profile to allow failures on osx as that has been quite unreliable in recent times