### PR TITLE
drop 0.5 support, modernize code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
 sudo: required
 dist: trusty
 julia:
-    - 0.5
     - 0.6
     - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5.0
+julia 0.6.0
 Compat 0.17.0
 BinDeps
 @osx Homebrew

--- a/src/Thrift.jl
+++ b/src/Thrift.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+__precompile__(true)
 
 module Thrift
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -460,8 +460,8 @@ mutable struct ThriftMetaAttribs
     fld::Symbol
     ttyp::Int32                     # thrift type
     required::Bool                  # required or optional
-    default::Array                  # the default value, empty array if none is specified, first element is used if something is specified
-    elmeta::Array                   # the ThriftMeta of a struct or element/key-value types if this is a list, set or map
+    default::Vector                 # the default value, empty array if none is specified, first element is used if something is specified
+    elmeta::Vector                  # the ThriftMeta of a struct or element/key-value types if this is a list, set or map
 end
 
 mutable struct ThriftMeta
@@ -579,7 +579,7 @@ function isfilled(obj)
     for fld in flds
         if fld.required
             !(fld.fld in fill) && (return false)
-            (fld.meta != nothing) && !isfilled(getfield(obj, fld.fld)) && (return false)
+            (fld.elmeta != nothing) && !isfilled(getfield(obj, fld.fld)) && (return false)
         end
     end
     true
@@ -590,7 +590,7 @@ end
 # utility methods
 function copy!(to::T, from::T) where T<:TMsg
     fillunset(to)
-    for name in fieldnames(totype)
+    for name in fieldnames(T)
         if isfilled(from, name)
             set_field!(to, name, getfield(from, name))
         end

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,6 +1,5 @@
-##
 # Base Thrift type system
-immutable TSTOP end
+struct TSTOP end
 const TVOID     = Void
 const TBOOL     = Bool
 const TBYTE     = UInt8     # TBYTE is actually I8 (signed)
@@ -18,7 +17,7 @@ const TLIST     = Array
 
 abstract type TMsg end
 
-type _enum_TTypes
+struct _enum_TTypes
     STOP::Int32
     VOID::Int32
     BOOL::Int32
@@ -59,39 +58,39 @@ thrift_type(::Type{TI64})                 = Int32(10)
 thrift_type(::Type{TSTRING})              = Int32(11)
 thrift_type(::Type{TUTF8})                = Int32(11)
 thrift_type(::Type{TBINARY})              = Int32(11)
-thrift_type{T<:AbstractString}(::Type{T}) = Int32(11)
-thrift_type{T<:Any}(::Type{T})            = Int32(12)
-thrift_type{T<:Dict}(::Type{T})           = Int32(13)
-thrift_type{T<:Set}(::Type{T})            = Int32(14)
-thrift_type{T<:Array}(::Type{T})          = Int32(15)
+thrift_type(::Type{T}) where {T<:AbstractString} = Int32(11)
+thrift_type(::Type{T}) where {T<:Any}            = Int32(12)
+thrift_type(::Type{T}) where {T<:Dict}           = Int32(13)
+thrift_type(::Type{T}) where {T<:Set}            = Int32(14)
+thrift_type(::Type{T}) where {T<:Array}          = Int32(15)
 
 const _container_type_ids = (TType.STRUCT, TType.MAP, TType.SET, TType.LIST)
 const _container_types    = (TSTRUCT, TMAP, TSET, TLIST)
 const _plain_type_ids = (TType.BOOL, TType.BYTE, TType.DOUBLE, TType.I16, TType.I32, TType.I64, TType.STRING)
 const _plain_types = (TBOOL, TBYTE, TDOUBLE, TI16, TI32, TI64, TBINARY, TUTF8)
 iscontainer(typ::Integer)       = (Int32(typ) in _container_type_ids)
-iscontainer{T}(typ::Type{T})    = iscontainer(thrift_type(typ))
+iscontainer(typ::Type{T}) where {T}    = iscontainer(thrift_type(typ))
 isplain(typ::Integer)           = (Int32(typ) in _plain_type_ids)
-isplain{T}(typ::Type{T})        = isplain(thrift_type(typ))
+isplain(typ::Type{T}) where {T}        = isplain(thrift_type(typ))
 
 ##
 # base processor method
-@compat abstract type TProcessor end
+abstract type TProcessor end
 process(tp::TProcessor) = nothing
 
 
 ##
 # base transport types
-@compat abstract type TTransport end
-@compat abstract type TServerTransport <: TTransport end
+abstract type TTransport end
+abstract type TServerTransport <: TTransport end
 
 ##
 # base server type
-@compat abstract type TServer end
+abstract type TServer end
 
 ##
 # base protocol types
-@compat abstract type TProtocol end
+abstract type TProtocol end
 
 ##
 # base protocol read and write methods
@@ -147,8 +146,8 @@ readDouble(p::TProtocol)           = read(p, TDOUBLE)
 readString(p::TProtocol)           = read(p, TUTF8)
 readBinary(p::TProtocol)           = read(p, TBINARY)
 
-skip{T<:TSTRUCT}(p::TProtocol, ::Type{T}) = skip_container(p, T)
-function skip_container{T<:TSTRUCT}(p::TProtocol, ::Type{T})
+skip(p::TProtocol, ::Type{T}) where {T<:TSTRUCT} = skip_container(p, T)
+function skip_container(p::TProtocol, ::Type{T}) where T<:TSTRUCT
     @logmsg("skip TSTRUCT")
     name = readStructBegin(p)
     while true
@@ -165,10 +164,10 @@ function skip_container{T<:TSTRUCT}(p::TProtocol, ::Type{T})
     return
 end
 
-read{T<:TSTRUCT}(p::TProtocol, ::Type{T}) = read(p, T())
-read_container{T<:TSTRUCT}(p::TProtocol, ::Type{T}) = read_container(p, T())
-read{T<:TSTRUCT}(p::TProtocol, val::T) = read_container(p, val)
-function read_container{T<:TSTRUCT}(p::TProtocol, val::T)
+read(p::TProtocol, ::Type{T}) where {T<:TSTRUCT} = read(p, T())
+read_container(p::TProtocol, ::Type{T}) where {T<:TSTRUCT} = read_container(p, T())
+read(p::TProtocol, val::T) where {T<:TSTRUCT} = read_container(p, val)
+function read_container(p::TProtocol, val::T) where T<:TSTRUCT
     @logmsg("read TSTRUCT $T")
     readStructBegin(p)
 
@@ -212,8 +211,8 @@ function read_container{T<:TSTRUCT}(p::TProtocol, val::T)
     val
 end
 
-write{T<:TSTRUCT}(p::TProtocol, val::T) = write_container(p, val)
-function write_container{T<:TSTRUCT}(p::TProtocol, val::T)
+write(p::TProtocol, val::T) where {T<:TSTRUCT} = write_container(p, val)
+function write_container(p::TProtocol, val::T) where T<:TSTRUCT
     m = meta(T)
     @logmsg("write TSTRUCT $T with meta $m")
     writeStructBegin(p, string(T))
@@ -237,8 +236,8 @@ function write_container{T<:TSTRUCT}(p::TProtocol, val::T)
     nothing
 end
 
-skip{T<:TMAP}(p::TProtocol, ::Type{T}) = skip_container(p, T)
-function skip_container{T<:TMAP}(p::TProtocol, ::Type{T})
+skip(p::TProtocol, ::Type{T}) where {T<:TMAP} = skip_container(p, T)
+function skip_container(p::TProtocol, ::Type{T}) where T<:TMAP
     @logmsg("skip TMAP $T")
     (ktype, vtype, size) = readMapBegin(p)
     if size > 0
@@ -253,9 +252,9 @@ function skip_container{T<:TMAP}(p::TProtocol, ::Type{T})
     return
 end
 
-read{T<:TMAP}(p::TProtocol, ::Type{T}) = read(p, T())
-read{T<:TMAP}(p::TProtocol, val::T) = read_container(p, val)
-function read_container{T<:TMAP}(p::TProtocol, val::T)
+read(p::TProtocol, ::Type{T}) where {T<:TMAP} = read(p, T())
+read(p::TProtocol, val::T) where {T<:TMAP} = read_container(p, val)
+function read_container(p::TProtocol, val::T) where T<:TMAP
     @logmsg("read TMAP $T")
     (ktype, vtype, size) = readMapBegin(p)
     if size > 0
@@ -295,8 +294,8 @@ function write_container(p::TProtocol, val::TMAP)
     writeMapEnd(p)
 end
 
-skip{T<:TSET}(p::TProtocol, ::Type{T}) = skip_container(p, T)
-function skip_container{T<:TSET}(p::TProtocol, ::Type{T})
+skip(p::TProtocol, ::Type{T}) where {T<:TSET} = skip_container(p, T)
+function skip_container(p::TProtocol, ::Type{T}) where T<:TSET
     @logmsg("skip TSET $T")
     (etype, size) = readSetBegin(p)
     if size > 0
@@ -308,9 +307,9 @@ function skip_container{T<:TSET}(p::TProtocol, ::Type{T})
     readSetEnd(p)
 end
 
-read{T<:TSET}(p::TProtocol, ::Type{T}) = read(p, T())
-read{T<:TSET}(p::TProtocol, val::T) = read_container(p, val)
-function read_container{T<:TSET}(p::TProtocol, val::T)
+read(p::TProtocol, ::Type{T}) where {T<:TSET} = read(p, T())
+read(p::TProtocol, val::T) where {T<:TSET} = read_container(p, val)
+function read_container(p::TProtocol, val::T) where T<:TSET
     @logmsg("read TSET $T")
     (etype, size) = readSetBegin(p)
     if size > 0
@@ -346,8 +345,8 @@ function write_container(p::TProtocol, val::TSET)
     writeSetEnd(p)
 end
 
-skip{T<:TLIST}(p::TProtocol, ::Type{T}) = skip_container(p, T)
-function skip_container{T<:TLIST}(p::TProtocol, ::Type{T})
+skip(p::TProtocol, ::Type{T}) where {T<:TLIST} = skip_container(p, T)
+function skip_container(p::TProtocol, ::Type{T}) where T<:TLIST
     @logmsg("skip TLIST $T")
     (etype, size) = readListBegin(p)
     if size > 0
@@ -359,9 +358,9 @@ function skip_container{T<:TLIST}(p::TProtocol, ::Type{T})
     readListEnd(p)
 end
 
-read{T<:TLIST}(p::TProtocol, ::Type{T}) = read(p, T())
-read{T<:TLIST}(p::TProtocol, val::T) = read_container(p, val)
-function read_container{T<:TLIST}(p::TProtocol, val::T)
+read(p::TProtocol, ::Type{T}) where {T<:TLIST} = read(p, T())
+read(p::TProtocol, val::T) where {T<:TLIST} = read_container(p, val)
+function read_container(p::TProtocol, val::T) where T<:TLIST
     @logmsg("read TLIST $T")
     (etype, size) = readListBegin(p)
     if size > 0
@@ -394,11 +393,11 @@ end
 
 ##
 # Exception types
-type TException <: Exception
+struct TException <: Exception
     message::AbstractString
 end
 
-type _enum_TApplicationExceptionTypes
+struct _enum_TApplicationExceptionTypes
     UNKNOWN::Int32
     UNKNOWN_METHOD::Int32
     INVALID_MESSAGE_TYPE::Int32
@@ -427,7 +426,7 @@ const _appex_msgs = [
     "Unsupported client type"
 ]
 
-type TApplicationException <: Exception
+struct TApplicationException <: Exception
     typ::Int32
     message::TUTF8
 
@@ -442,7 +441,7 @@ meta(t::Type{TApplicationException}) = meta(t, Symbol[], [2,1], Dict{Symbol,Any}
 
 ##
 # Message types
-type _enum_TMessageType
+struct _enum_TMessageType
     CALL::Int32
     REPLY::Int32
     EXCEPTION::Int32
@@ -456,7 +455,7 @@ const MessageType = _enum_TMessageType(Int32(1), Int32(2), Int32(3), Int32(4))
 ##
 # Thrift Structure Metadata
 
-type ThriftMetaAttribs
+mutable struct ThriftMetaAttribs
     fldnum::Int                     # the field number in the structure
     fld::Symbol
     ttyp::Int32                     # thrift type
@@ -465,16 +464,16 @@ type ThriftMetaAttribs
     elmeta::Array                   # the ThriftMeta of a struct or element/key-value types if this is a list, set or map
 end
 
-type ThriftMeta
+mutable struct ThriftMeta
     jtype::Type
     symdict::Dict{Symbol,ThriftMetaAttribs}
     numdict::Dict{Int,ThriftMetaAttribs}
-    ordered::Array{ThriftMetaAttribs,1}
+    ordered::Vector{ThriftMetaAttribs}
 
-    ThriftMeta(jtype::Type, ordered::Array{ThriftMetaAttribs,1}) = _setmeta(new(), jtype, ordered)
+    ThriftMeta(jtype::Type, ordered::Vector{ThriftMetaAttribs}) = _setmeta(new(), jtype, ordered)
 end
 
-function _setmeta(meta::ThriftMeta, jtype::Type, ordered::Array{ThriftMetaAttribs,1})
+function _setmeta(meta::ThriftMeta, jtype::Type, ordered::Vector{ThriftMetaAttribs})
     symdict = Dict{Symbol,ThriftMetaAttribs}()
     numdict = Dict{Int,ThriftMetaAttribs}()
     for attrib in ordered
@@ -490,7 +489,7 @@ end
 julia_type(fattr::ThriftMetaAttribs, m::ThriftMeta) = fieldtype(m.jtype, fattr.fld)
 
 const _metacache = Dict{Type, ThriftMeta}()
-const _fillcache = Dict{UInt, Array{Symbol,1}}()
+const _fillcache = Dict{UInt, Vector{Symbol}}()
 
 meta(typ::Type) = meta(typ, Symbol[], Int[], Dict{Symbol,Any}())
 function meta(typ::Type, optional::Array, numbers::Array, defaults::Dict, cache::Bool=true)
@@ -498,9 +497,9 @@ function meta(typ::Type, optional::Array, numbers::Array, defaults::Dict, cache:
     for (k,v) in defaults
         d[k] = v
     end
-    meta(typ, convert(Array{Symbol,1}, optional), convert(Array{Int,1}, numbers), d, cache)
+    meta(typ, convert(Vector{Symbol}, optional), convert(Vector{Int}, numbers), d, cache)
 end
-function meta(typ::Type, optional::Array{Symbol,1}, numbers::Array{Int,1}, defaults::Dict{Symbol,Any}, cache::Bool=true)
+function meta(typ::Type, optional::Vector{Symbol}, numbers::Vector{Int}, defaults::Dict{Symbol,Any}, cache::Bool=true)
     haskey(_metacache, typ) && return _metacache[typ]
 
     m = ThriftMeta(typ, ThriftMetaAttribs[])
@@ -589,7 +588,7 @@ end
 
 ##
 # utility methods
-function copy!{T<:TMsg}(to::T, from::T)
+function copy!(to::T, from::T) where T<:TMsg
     fillunset(to)
     for name in fieldnames(totype)
         if isfilled(from, name)
@@ -613,7 +612,7 @@ get_field(obj, fld::Symbol) = isfilled(obj, fld) ? getfield(obj, fld) : error("u
 clear = fillunset
 has_field(obj, fld::Symbol) = isfilled(obj, fld)
 
-function thriftbuild{T}(::Type{T}, nv::Dict{Symbol}=Dict{Symbol,Any}())
+function thriftbuild(::Type{T}, nv::Dict{Symbol}=Dict{Symbol,Any}()) where T
     obj = T()
     for (n,v) in nv
         fldtyp = fieldtype(T, n)

--- a/src/base.jl
+++ b/src/base.jl
@@ -16,6 +16,8 @@ const TMAP      = Dict
 const TSET      = Set
 const TLIST     = Array
 
+abstract type TMsg end
+
 type _enum_TTypes
     STOP::Int32
     VOID::Int32
@@ -587,7 +589,7 @@ end
 
 ##
 # utility methods
-function copy!{T}(to::T, from::T)
+function copy!{T<:TMsg}(to::T, from::T)
     fillunset(to)
     for name in fieldnames(totype)
         if isfilled(from, name)

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -2,16 +2,16 @@ const MSB = 0x80
 const MASK7 = 0x7f
 const MASK8 = 0xff
 
-const _wfbuf = (Array{UInt8,1}(1), Array{UInt8,1}(2), Array{UInt8,1}(4), Array{UInt8,1}(8), Array{UInt8,1}(16))
+const _wfbuf = (Vector{UInt8}(1), Vector{UInt8}(2), Vector{UInt8}(4), Vector{UInt8}(8), Vector{UInt8}(16))
 
 const TIO = Union{IO, TTransport}
 
-function _write_fixed{T <: Unsigned}(io::TIO, ux::T, bigendian::Bool)
+function _write_fixed(io::TIO, ux::T, bigendian::Bool) where T <: Unsigned
     N = sizeof(ux)
     _write_fixed(io, ux, _wfbuf[Int(log2(N))+1], bigendian ? (N:-1:1) : (1:N))
 end
 
-function _write_fixed{T <: Unsigned, R <: Range}(io::TIO, ux::T, a::Array{UInt8,1}, r::R)
+function _write_fixed(io::TIO, ux::T, a::Vector{UInt8}, r::R) where {T <: Unsigned, R <: Range}
     for n in r
         a[n] = UInt8(ux & MASK8)
         ux >>>= 8
@@ -19,7 +19,7 @@ function _write_fixed{T <: Unsigned, R <: Range}(io::TIO, ux::T, a::Array{UInt8,
     write(io, a)
 end
 
-function _read_fixed{T <: Unsigned}(io::TIO, ret::T, N::Int, bigendian::Bool)
+function _read_fixed(io::TIO, ret::T, N::Int, bigendian::Bool) where T <: Unsigned
     r = bigendian ? ((N-1):-1:0) : (0:1:(N-1))
     for n in r
         byte = convert(T, read(io, UInt8))
@@ -28,7 +28,7 @@ function _read_fixed{T <: Unsigned}(io::TIO, ret::T, N::Int, bigendian::Bool)
     ret
 end
 
-function _write_uleb{T <: Integer}(io::TIO, x::T)
+function _write_uleb(io::TIO, x::T) where T <: Integer
     nw = 0
     cont = true
     while cont
@@ -43,7 +43,7 @@ function _write_uleb{T <: Integer}(io::TIO, x::T)
     nw
 end
 
-function _read_uleb{T <: Integer}(io::TIO, typ::Type{T})
+function _read_uleb(io::TIO, typ::Type{T}) where T <: Integer
     res = convert(typ, 0)
     n = 0
     byte = UInt8(MSB)
@@ -55,13 +55,13 @@ function _read_uleb{T <: Integer}(io::TIO, typ::Type{T})
     res
 end
 
-function _write_zigzag{T <: Integer}(io::TIO, x::T)
+function _write_zigzag(io::TIO, x::T) where T <: Integer
     nbits = 8*sizeof(x)
     zx = xor((x << 1), (x >> (nbits-1)))
     _write_uleb(io, zx)
 end
 
-function _read_zigzag{T <: Integer}(io::TIO, typ::Type{T})
+function _read_zigzag(io::TIO, typ::Type{T}) where T <: Integer
     zx = _read_uleb(io, UInt64)
     # result is positive if zx is even
     convert(typ, iseven(zx) ? (zx >>> 1) : -((zx+1) >>> 1))

--- a/src/processor.jl
+++ b/src/processor.jl
@@ -1,14 +1,14 @@
 ##
 # The default processor core.
 
-type ThriftHandler{I,O}
+mutable struct ThriftHandler{I,O}
     name::AbstractString
     fn::Function
     intyp::Type{I}
     outtyp::Type{O}
 end
 
-type ThriftProcessor
+mutable struct ThriftProcessor
     handlers::Dict{AbstractString, ThriftHandler}
     use_spawn::Bool
     extends::ThriftProcessor

--- a/src/sasl.jl
+++ b/src/sasl.jl
@@ -23,7 +23,7 @@ const SASL_ERR_UNSUPPORTED  = 1
 const SASL_ERR_NEGOTIATION  = 2
 const SASL_ERR_INVALID      = 3
 
-type SASLException <: Exception
+struct SASLException <: Exception
     code::Int
     message::AbstractString
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,5 +1,5 @@
 
-type TServerBase
+mutable struct TServerBase
     srvr_t::TServerTransport
     processor::TProcessor
     in_t::Function
@@ -32,7 +32,7 @@ close(srvr::TServer) = close(srvr.base.srvr_t)
 
 ##
 # Blocking server. Requests are processed in the main task.
-type TSimpleServer <: TServer
+mutable struct TSimpleServer <: TServer
     base::TServerBase
     TSimpleServer(srvr_t::TServerTransport, processor::TProcessor, in_t::Function, in_p::Function, out_t::Function, out_p::Function) = new(TServerBase(srvr_t, processor, in_t, in_p, out_t, out_p))
 end
@@ -51,14 +51,14 @@ end
 
 ##
 # Task server. Tasks are spawned for each connection.
-type TTaskServer <: TServer
+mutable struct TTaskServer <: TServer
     base::TServerBase
     TTaskServer(srvr_t::TServerTransport, processor::TProcessor, in_t::Function, in_p::Function, out_t::Function, out_p::Function) = new(TServerBase(srvr_t, processor, in_t, in_p, out_t, out_p))
 end
 
 ##
 # Process Pool Server
-type TProcessPoolServer <: TServer
+mutable struct TProcessPoolServer <: TServer
     base::TServerBase
     function TProcessPoolServer(srvr_t::TServerTransport, processor::TProcessor, in_t::Function, in_p::Function, out_t::Function, out_p::Function) 
         distribute(processor)

--- a/test/filetransport_tests.jl
+++ b/test/filetransport_tests.jl
@@ -12,6 +12,13 @@ function testfiletransport()
     open(fname, "w") do f
         t = TFileTransport(f)
         p = TCompactProtocol(t)
+
+        @test open(t) === nothing
+        @test close(t) === nothing
+        @test flush(t) === nothing
+        @test isa(Thrift.rawio(t), IO)
+        @test isopen(t)
+
         for i in 1:5
             write(p, s1)
         end

--- a/test/memtransport_tests.jl
+++ b/test/memtransport_tests.jl
@@ -9,10 +9,25 @@ function testmemtransport()
     t = TMemoryTransport()
     p = TCompactProtocol(t)
 
+    @test open(t) === nothing
+    @test close(t) === nothing
+    @test flush(t) === nothing
+    @test isa(Thrift.rawio(t), IOBuffer)
+    @test isopen(t)
+
     s1 = "Hello World"
     write(p, s1)
     s2 = read(p, typeof(s1))
     @test s2 == s1
+
+    t = TMemoryTransport()
+    p = TCompactProtocol(t)
+    write(p, s1)
+    t = TMemoryTransport(take!(t.buff))
+    p = TCompactProtocol(t)
+    s2 = read(p, typeof(s1))
+    @test s2 == s1
+
     println("passed.")
 end
 

--- a/test/utils_tests.jl
+++ b/test/utils_tests.jl
@@ -33,9 +33,50 @@ function test_container_check()
     end
 end
 
+mutable struct TestMetaAllTypes <: Thrift.TMsg
+  bool_val::Bool
+  byte_val::UInt8
+  i16_val::Int16
+  i32_val::Int32
+  i64_val::Int64
+  double_val::Float64
+  string_val::String
+  TestMetaAllTypes() = (o=new(); fillunset(o); o)
+end # mutable struct AllTypes
+
+function test_meta()
+    @test !Thrift.isplain(TestMetaAllTypes)
+    @test Thrift.iscontainer(TestMetaAllTypes)
+
+    types = TestMetaAllTypes()
+    @test !isfilled(types)
+    @test !isfilled(types, :bool_val)
+
+    set_field!(types, :bool_val, true)
+    @test isfilled(types, :bool_val)
+    @test !isfilled(types)
+
+    set_field!(types, :byte_val,    UInt8(1))
+    set_field!(types, :i16_val,     Int16(1))
+    set_field!(types, :i32_val,     Int32(1))
+    set_field!(types, :i64_val,     Int64(1))
+    set_field!(types, :double_val,  1.1)
+    set_field!(types, :string_val,  "1")
+    @test isfilled(types)
+    @test isinitialized(types)
+
+    types2 = TestMetaAllTypes()
+    @test !isfilled(types2)
+    copy!(types2, types)
+    @test isfilled(types2)
+
+    nothing
+end
+
 println("Testing utils functions...")
 test_enum()
 test_container_check()
+test_meta()
 println("passed.")
 
 end

--- a/test/utils_tests.jl
+++ b/test/utils_tests.jl
@@ -3,7 +3,7 @@ module ThriftUtilsTests
 using Thrift
 using Base.Test
 
-type _enum_TestEnum
+struct _enum_TestEnum
     BOOLEAN::Int32
     INT32::Int32
     INT64::Int32


### PR DESCRIPTION
- dropped Julia 0.5 support
- modernized code a bit
- all generated thrift message types now inherit from abstract `TMsg` type, to avoid common methods 
(like `copy!`) clashing with other packages.
- added some tests, and fixed few utility methods