### PR TITLE
Fix deprecated array syntax

### DIFF
--- a/src/protocols.jl
+++ b/src/protocols.jl
@@ -111,7 +111,7 @@ function readMessageBegin(p::TBinaryProtocol)
         seqid = readI32(p)
     else
         p.strict_read && throw(TProtocolException(ProtocolExceptionType.BAD_VERSION, "No protocol version header"))
-        name =  String(read!(p, Array(UInt8, sz)))
+        name =  String(read!(p, Array{UInt8}(Int(sz))))
         typ = Int32(readByte(p))
         seqid = readI32(p)
     end


### PR DESCRIPTION
On 0.6.4 (release-0.6 branch), this line causes a deprecation warning:

```
WARNING: Array(::Type{T}, m::Integer) where T is deprecated, use Array{T}(Int(m)) instead.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:70
 [2] Array(::Type{UInt8}, ::UInt32) at ./deprecated.jl:57
 [3] readMessageBegin(::Thrift.TBinaryProtocol) at /Users/randyzwitch/.julia/v0.6/Thrift/src/protocols.jl:114
 [4] sql_execute(::MapD.MapDClient, ::String, ::String, ::Bool, ::String, ::Int32, ::Int32) at /Users/randyzwitch/.julia/v0.6/MapD/src/mapd_client.jl:529
 [5] sql_execute(::MapD.MapDConnection, ::String, ::Bool, ::Int64, ::Int64) at /Users/randyzwitch/.julia/v0.6/MapD/src/misc.jl:74
 [6] include_string(::String, ::String) at ./loading.jl:522
 [7] include_string(::String, ::String, ::Int64) at /Users/randyzwitch/.julia/v0.6/CodeTools/src/eval.jl:30
 [8] include_string(::Module, ::String, ::String, ::Int64, ::Vararg{Int64,N} where N) at /Users/randyzwitch/.julia/v0.6/CodeTools/src/eval.jl:34
 [9] (::Atom.##102#107{String,Int64,String})() at /Users/randyzwitch/.julia/v0.6/Atom/src/eval.jl:82
 [10] withpath(::Atom.##102#107{String,Int64,String}, ::String) at /Users/randyzwitch/.julia/v0.6/CodeTools/src/utils.jl:30
 [11] withpath(::Function, ::String) at /Users/randyzwitch/.julia/v0.6/Atom/src/eval.jl:38
 [12] hideprompt(::Atom.##101#106{String,Int64,String}) at /Users/randyzwitch/.julia/v0.6/Atom/src/repl.jl:67
 [13] macro expansion at /Users/randyzwitch/.julia/v0.6/Atom/src/eval.jl:80 [inlined]
 [14] (::Atom.##100#105{Dict{String,Any}})() at ./task.jl:80
while loading /Users/randyzwitch/.julia/v0.6/MapD/test/runtests.jl, in expression starting on line 58
```