### PR TITLE
enable installation and minimal test on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Thrift.jl
 
 [![Build Status](https://travis-ci.org/tanmaykm/Thrift.jl.png)](https://travis-ci.org/tanmaykm/Thrift.jl)
+[![Build status](https://ci.appveyor.com/api/projects/status/56l7lbwk5fwbtnoo/branch/master?svg=true)](https://ci.appveyor.com/project/tanmaykm/thrift-jl/branch/master)
 
 [**Apache Thrift**](http://thrift.apache.org/) is a lightweight, language-independent software stack with an associated code generation mechanism for RPC.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,40 @@
+environment:
+  matrix:
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $env:JULIA_URL,
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"Thrift\"); Pkg.build(\"Thrift\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"Thrift\")"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,20 @@
 using Compat
 
-include("gen.jl")
+if Compat.Sys.iswindows()
+    info("No tests enabled for for your platform by default.")
+else
+    include("gen.jl")
 
-if VERSION < v"0.7.0-alpha"
-    macro isdefined(x)
+    if VERSION < v"0.7.0-alpha"
+        macro isdefined(x)
+        end
     end
+
+    ENV["TEST_SRVR_ASYNC"] = "true"
+    include("srvr.jl")
+    include("clnt.jl")
+
+    include("memtransport_tests.jl")
+    include("filetransport_tests.jl")
+    include("utils_tests.jl")
 end
-
-ENV["TEST_SRVR_ASYNC"] = "true"
-include("srvr.jl")
-include("clnt.jl")
-
-include("memtransport_tests.jl")
-include("filetransport_tests.jl")
-include("utils_tests.jl")


### PR DESCRIPTION
- Build on Windows does not fail, but does not build anything either. Building the compiler is not necessary unless one needs to work on thrift IDLs.
- Tests on Windows just loads the package for now.