### PR TITLE
make exception types mutable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - osx
 julia:
     - 1.0
+    - 1.1
     - nightly
 matrix:
   fast_finish: true

--- a/src/base.jl
+++ b/src/base.jl
@@ -393,7 +393,7 @@ end
 
 ##
 # Exception types
-struct TException <: Exception
+mutable struct TException <: Exception
     message::AbstractString
 end
 
@@ -426,7 +426,7 @@ const _appex_msgs = [
     "Unsupported client type"
 ]
 
-struct TApplicationException <: Exception
+mutable struct TApplicationException <: Exception
     typ::Int32
     message::TUTF8
 


### PR DESCRIPTION
Make exception types mutable, because they are marshalled across wire in some cases (JuliaDatabases/Hive.jl#28).

Also add Julia 1.1 to CI.