### PR TITLE
use Base Logging macros

### DIFF
--- a/src/Thrift.jl
+++ b/src/Thrift.jl
@@ -33,6 +33,10 @@ export ThriftProcessor, ThriftHandler, process, handle, extend, distribute
 # from server.jl
 export TSimpleServer, TTaskServer, TProcessPoolServer, serve
 
+if !isdefined(Base, :fieldtypes)
+    fieldtypes(T::Type) = ntuple(i -> fieldtype(T, i), fieldcount(T))
+end
+
 include("base.jl")
 include("codec.jl")
 include("sasl.jl")

--- a/src/Thrift.jl
+++ b/src/Thrift.jl
@@ -1,10 +1,9 @@
 module Thrift
 
 using Distributed
-
 using Sockets
-import Sockets: TCPServer, listen, accept
 
+import Sockets: TCPServer, listen, accept
 import Base: open, close, isopen, read, read!, write, flush, skip, show, copy!
 
 export open, close, isopen, read, read!, write, flush, skip, listen, accept, show, copy!
@@ -33,18 +32,6 @@ export ThriftProcessor, ThriftHandler, process, handle, extend, distribute
 
 # from server.jl
 export TSimpleServer, TTaskServer, TProcessPoolServer, serve
-
-# enable logging only during debugging
-#using Logging
-#const logger = Logging.configure(level=DEBUG)
-##const logger = Logging.configure(filename="/tmp/thrift$(getpid()).log", level=DEBUG)
-#macro logmsg(s)
-#    quote
-#        debug($(esc(s)))
-#    end
-#end
-macro logmsg(s)
-end
 
 include("base.jl")
 include("codec.jl")

--- a/src/sasl.jl
+++ b/src/sasl.jl
@@ -67,11 +67,11 @@ end
 
 function sasl_read(io::IO)
     status = read(io, UInt8)
-    @logmsg("read_sasl read status $status")
+    @debug("read_sasl", status)
     len = _read_fixed(io, UInt32(0), 4, true)
-    @logmsg("read_sasl read len $len")
+    @debug("read_sasl", len)
     data = read!(io, Vector{UInt8}(undef, len))
-    @logmsg("read_sasl read data $data")
+    @debug("read_sasl", data)
     (status, len, data)
 end
 
@@ -92,18 +92,18 @@ function sasl_negotiate_plain(io::IO, callback::Function)
 
     # start negotiation, indicate protocol
     nbyt = sasl_write(io, SASL_START, SASL_MECH_PLAIN)
-    @logmsg("negotiate_sasl wrote $nbyt bytes")
+    @debug("negotiate_sasl wrote", nbyt)
     # send credentials
     nbyt = sasl_write(io, SASL_OK, take!(creds))
-    @logmsg("negotiate_sasl wrote $nbyt bytes")
+    @debug("negotiate_sasl wrote", nbyt)
 
     (status, len, data) = sasl_read(io)
-    @logmsg("negotiate_sasl read $status, $len, $data")
+    @debug("negotiate_sasl read", status, len, data)
     validate_sasl_status(status, data, (SASL_COMPLETE,))
 
     # send COMPLETE
     #nbyt = sasl_write(io, SASL_COMPLETE, "")
-    #@logmsg("negotiate_sasl wrote $nbyt bytes")
+    #@debug("negotiate_sasl wrote $nbyt bytes")
 
     nothing
 end

--- a/src/transports.jl
+++ b/src/transports.jl
@@ -39,11 +39,11 @@ flush(t::TSASLClientTransport)  = flush(t.tp)
 read!(t::TSASLClientTransport, buff::Vector{UInt8}) = read!(t.tp, buff)
 read(t::TSASLClientTransport, UInt8) = read(t.tp, UInt8)
 function write(t::TSASLClientTransport, buff::Vector{UInt8})
-    @logmsg("TSASLClientTransport buffering $(length(buff)) bytes")
+    @debug("TSASLClientTransport buffering bytes", len=length(buff))
     write(t.tp, buff)
 end
 function write(t::TSASLClientTransport, b::UInt8)
-    @logmsg("TSASLClientTransport buffering 1 byte")
+    @debug("TSASLClientTransport buffering 1 byte")
     write(t.tp, b)
 end
 
@@ -67,11 +67,11 @@ isopen(t::TFramedTransport) = isopen(t.tp)
 
 readframesz(t::TFramedTransport) = _read_fixed(t.tp, UInt32(0), 4, true)
 function readframe(t::TFramedTransport)
-    @logmsg("TFramedTransport reading frame")
+    @debug("TFramedTransport reading frame")
     sz = readframesz(t)
-    @logmsg("TFramedTransport reading frame of $sz bytes")
+    @debug("TFramedTransport reading frame", sz)
     write(t.rbuff, read!(t.tp, Vector{UInt8}(undef,sz)))
-    @logmsg("TFramedTransport read frame of $sz bytes")
+    @debug("TFramedTransport read frame", sz)
     nothing
 end
 
@@ -83,7 +83,7 @@ function read!(t::TFramedTransport, buff::Vector{UInt8})
         navlb = bytesavailable(t.rbuff)
         nremain = ntotal - nread
         if navlb < nremain
-            @logmsg("navlb: $navlb, nremain: $nremain, reading new frame")
+            @debug("reading new frame", navlb, nremain)
             readframe(t)
             navlb = bytesavailable(t.rbuff)
         end
@@ -102,21 +102,21 @@ function read(t::TFramedTransport, UInt8)
 end
 
 function write(t::TFramedTransport, buff::Vector{UInt8})
-    @logmsg("TFramedTransport buffering $(length(buff)) bytes")
+    @debug("TFramedTransport buffering bytes", len=length(buff))
     write(t.wbuff, buff)
 end
 function write(t::TFramedTransport, b::UInt8)
-    @logmsg("TFramedTransport buffering 1 byte")
+    @debug("TFramedTransport buffering 1 byte")
     write(t.wbuff, b)
 end
 function flush(t::TFramedTransport)
     szbuff = IOBuffer()
     navlb = bytesavailable(t.wbuff)
-    @logmsg("sending data of length $navlb")
+    @debug("sending data", navlb)
     _write_fixed(szbuff, UInt32(navlb), true)
     nbyt = write(t.tp, take!(szbuff))
     nbyt += write(t.tp, take!(t.wbuff))
-    @logmsg("wrote frame of size $nbyt")
+    @debug("wrote frame", nbyt)
     flush(t.tp)
 end
 


### PR DESCRIPTION
Using Base Logging macros for debug messages instead of the earlier used `@logmsg` macro.

fixes #56 