### PR TITLE
fix hello example import

### DIFF
--- a/test/hello/clnt.jl
+++ b/test/hello/clnt.jl
@@ -3,17 +3,16 @@ import Thrift.process, Thrift.meta
 
 # include the generated hello module
 include("gen-jl/hello/hello.jl");
-import hello.SayHelloClient, hello.hello_to
 
 # create a client instance with our choice of protocol and transport
 clnt_transport = TSocket(19999)
 proto = TBinaryProtocol(clnt_transport)
-clnt = SayHelloClient(proto)
+clnt = hello.SayHelloClient(proto)
 
 # open a connection
 open(clnt_transport)
 # invoke service and print the result
-println(hello_to(clnt, "Julia"))
+println(hello.hello_to(clnt, "Julia"))
 # close connection
 close(clnt_transport)
 

--- a/test/hello/srvr.jl
+++ b/test/hello/srvr.jl
@@ -3,10 +3,9 @@ import Thrift.process, Thrift.meta
 
 # include the generated module, which in-turn includes our implementation code in `hello_impl.jl`
 include("gen-jl/hello/hello.jl");
-import hello.SayHelloProcessor
 
 # create a server instance with our choice of protocol and transport
-srvr_processor = SayHelloProcessor()
+srvr_processor = hello.SayHelloProcessor()
 srvr_transport = TServerSocket(19999)
 srvr = TSimpleServer(srvr_transport, srvr_processor, x->x, x->TBinaryProtocol(x), x->x, x->TBinaryProtocol(x))
 


### PR DESCRIPTION
Fixes this error when following the README example instructions on Julia 1.3.1:
```
~/.julia/dev/Thrift/test/hello$ julia srvr.jl
ERROR: LoadError: ArgumentError: Package hello not found in current path:
- Run `import Pkg; Pkg.add("hello")` to install the hello package.
```
