### PR TITLE
write fixes (threads), add missing isfilled vector

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -228,6 +228,8 @@ function write_container(p::TProtocol, val::T) where T<:TSTRUCT
         fld = getproperty(val, attrib.fld)
         if (attrib.ttyp == TType.STRING) && isa(fld, Vector{UInt8})
             write(p, fld, true)
+        elseif attrib.ttyp == TType.BOOL
+            writeBool(p, fld)
         else
             write(p, fld)
         end
@@ -479,6 +481,9 @@ function isfilled(obj)
         end
     end
     true
+end
+function isfilled(vec::Vector{T}) where T<:TMsg
+    isempty(vec) || all(isfilled.(vec))
 end
 
 ##

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -2,16 +2,15 @@ const MSB = 0x80
 const MASK7 = 0x7f
 const MASK8 = 0xff
 
-const _wfbuf = (Vector{UInt8}(undef, 1), Vector{UInt8}(undef, 2), Vector{UInt8}(undef, 4), Vector{UInt8}(undef, 8), Vector{UInt8}(undef, 16))
-
 const TIO = Union{IO, TTransport}
 
 function _write_fixed(io::TIO, ux::T, bigendian::Bool) where T <: Unsigned
     N = sizeof(ux)
-    _write_fixed(io, ux, _wfbuf[Int(log2(N))+1], bigendian ? (N:-1:1) : (1:N))
+    _write_fixed(io, ux, bigendian ? (N:-1:1) : (1:N))
 end
 
-function _write_fixed(io::TIO, ux::T, a::Vector{UInt8}, r::R) where {T <: Unsigned, R <: AbstractRange}
+function _write_fixed(io::TIO, ux::T, r::R) where {T <: Unsigned, R <: AbstractRange}
+    a = Vector{UInt8}(undef, sizeof(ux))
     for n in r
         a[n] = UInt8(ux & MASK8)
         ux >>>= 8


### PR DESCRIPTION
- fix thread safety of `_write_fixed` method, remove reliance on globals
- fix write of Bool struct members using compact protocol
- add missing `isfilled` method for Vectors