### PR TITLE
prevent method overwrite error at precompilation

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -66,7 +66,7 @@ writeVarint(io::IO, i::T) where {S <: Integer, T <: Base.Enums.Enum{S}} = writeV
 Read a varint from the IO stream. Default is 64-bit integer.
 """
 readVarint(io::IO, t::Type{T}=Int64) where {T <: Integer} = _read_uleb(io, t)
-readVarint(io::IO, t::Type{T}=Int64) where {S <: Integer, T <: Base.Enums.Enum{S}} = T(readVarint(io, S))
+readVarint(io::IO, t::Type{T}) where {S <: Integer, T <: Base.Enums.Enum{S}} = T(readVarint(io, S))
 
 """
     transform_data(codec, data::Vector{UInt8})


### PR DESCRIPTION
The `readVarint` signature with default argument was causing a method overwrite warning during precompilation.

```
[ Info: Precompiling Thrift [8d9c9c80-f77e-5080-9541-c6f69d204e22]
WARNING: Method definition readVarint(IO) where {S<:Integer} in module Thrift at /home/tan/.julia/dev/Thrift/src/utils.jl:68 overwritten at /home/tan/.julia/dev/Thrift/src/utils.jl:69.
  ** incremental compilation may be fatally broken for this module **
```

Removing the default value to prevent it.

ref: #70 

cc: @tk3369 